### PR TITLE
chore: add dependabot cooldown, align interval and assignee

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,13 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
-      interval: "monthly"
+      interval: weekly
     open-pull-requests-limit: 10
     assignees:
-      - "goloroden"
+      - thenativeweb/internal_dev
     labels:
       - "Dependencies"
     allow:
@@ -17,11 +19,13 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
-      interval: "monthly"
+      interval: weekly
     open-pull-requests-limit: 10
     assignees:
-      - "goloroden"
+      - thenativeweb/internal_dev
     labels:
       - "Dependencies"
     commit-message:


### PR DESCRIPTION
Align the Dependabot configuration with the other repositories:

- Add a 7-day `cooldown` (`default-days: 7`) to every update block
- Use `weekly` as update interval
- Set the assignee to `thenativeweb/internal_dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)